### PR TITLE
Fail Fast when Tables or Columns does not exists in a Relationship

### DIFF
--- a/extractor/src/main/java/org/databaseliner/Extractor.java
+++ b/extractor/src/main/java/org/databaseliner/Extractor.java
@@ -51,9 +51,8 @@ public class Extractor {
         	System.err.println("usage: Extractor [config_filename]");
         } else {
         	extractor = new Extractor(args[0]);
+            extractor.extract();
+            System.exit(extractor.extractionModel.failed() ? 1 : 0);
         }
-        extractor.extract();
 	}
-
-
 }

--- a/extractor/src/main/java/org/databaseliner/extraction/CompositeReferingToMultipleTablesRelationship.java
+++ b/extractor/src/main/java/org/databaseliner/extraction/CompositeReferingToMultipleTablesRelationship.java
@@ -162,6 +162,7 @@ public class CompositeReferingToMultipleTablesRelationship extends BaseRelations
             if (seedTable == null) {
                 throw new ExtractionModel.TableMissingException("attept to reference non existant table " + seedTableName);
             }
+            tableToFill.getColumnWithName(column);
             seedTable.getColumnWithName(seedColumn); // throws if missing
         }
 	}

--- a/extractor/src/main/java/org/databaseliner/extraction/CompositeReferingToMultipleTablesRelationship.java
+++ b/extractor/src/main/java/org/databaseliner/extraction/CompositeReferingToMultipleTablesRelationship.java
@@ -3,10 +3,7 @@ package org.databaseliner.extraction;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.databaseliner.extraction.model.Column;
-import org.databaseliner.extraction.model.Row;
-import org.databaseliner.extraction.model.Table;
-import org.databaseliner.extraction.model.TableName;
+import org.databaseliner.extraction.model.*;
 import org.databaseliner.output.SqlStringOutputter;
 
 public class CompositeReferingToMultipleTablesRelationship extends BaseRelationship {
@@ -162,6 +159,9 @@ public class CompositeReferingToMultipleTablesRelationship extends BaseRelations
 		}
 
         public void verify() {
+            if (seedTable == null) {
+                throw new ExtractionModel.TableMissingException("attept to reference non existant table " + seedTableName);
+            }
             seedTable.getColumnWithName(seedColumn); // throws if missing
         }
 	}

--- a/extractor/src/main/java/org/databaseliner/extraction/CompositeReferingToMultipleTablesRelationship.java
+++ b/extractor/src/main/java/org/databaseliner/extraction/CompositeReferingToMultipleTablesRelationship.java
@@ -107,6 +107,13 @@ public class CompositeReferingToMultipleTablesRelationship extends BaseRelations
 		}
 		return sqlStatementTemplate.toString();
 	}
+
+    @Override
+    public void verify() {
+        for(TableRelationship relationship : tableRelationships) {
+            relationship.verify();
+        }
+    }
 	
 	@Override
 	public String toHtmlString() {
@@ -153,6 +160,10 @@ public class CompositeReferingToMultipleTablesRelationship extends BaseRelations
 		public String getSeedIdentifier() {
 			return seedTableName + "." + seedColumn;
 		}
+
+        public void verify() {
+            seedTable.getColumnWithName(seedColumn); // throws if missing
+        }
 	}
 
 }

--- a/extractor/src/main/java/org/databaseliner/extraction/ConditionalOnSeedTableRelationship.java
+++ b/extractor/src/main/java/org/databaseliner/extraction/ConditionalOnSeedTableRelationship.java
@@ -55,8 +55,14 @@ public class ConditionalOnSeedTableRelationship extends RefersToRelationship {
 	public void addCondition(String whenColumnName, String valueToEqual) {
 		this.condition = new Condition(whenColumnName, valueToEqual);
 	}
-	
-	@Override
+
+    @Override
+    public void verify() {
+        super.verify();
+        seedTable.getColumnWithName(condition.whenColumnName); // throws if missing
+    }
+
+    @Override
 	public String toHtmlString() {
 		
 		return super.toHtmlString() + " " + condition;

--- a/extractor/src/main/java/org/databaseliner/extraction/IgnoredRelationship.java
+++ b/extractor/src/main/java/org/databaseliner/extraction/IgnoredRelationship.java
@@ -45,7 +45,12 @@ public class IgnoredRelationship extends BaseRelationship {
 		return false; 
 	}
 
-	@Override
+    @Override
+    public void verify() {
+        // nothing can go wrong here
+    }
+
+    @Override
 	public String toHtmlString() {
 		return String.format("relationship between [%s.%s] and  <a href=\"#%s\">[%s.%s]</a> is ignored", seedTableName, seedColumn, toTableName.getHtmlIdSafeName(), toTableName, toColumn);
 	}

--- a/extractor/src/main/java/org/databaseliner/extraction/RefersToRelationship.java
+++ b/extractor/src/main/java/org/databaseliner/extraction/RefersToRelationship.java
@@ -40,6 +40,7 @@ public class RefersToRelationship extends BaseRelationship {
         if (seedTable == null) {
             throw new ExtractionModel.TableMissingException("attept to reference non existant table " + seedTableName);
         }
+        tableToFill.getColumnWithName(column);
         seedTable.getColumnWithName(seedColumnName); // throws if missing
     }
 

--- a/extractor/src/main/java/org/databaseliner/extraction/RefersToRelationship.java
+++ b/extractor/src/main/java/org/databaseliner/extraction/RefersToRelationship.java
@@ -4,10 +4,7 @@ package org.databaseliner.extraction;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.databaseliner.extraction.model.Column;
-import org.databaseliner.extraction.model.Row;
-import org.databaseliner.extraction.model.Table;
-import org.databaseliner.extraction.model.TableName;
+import org.databaseliner.extraction.model.*;
 import org.databaseliner.output.SqlStringOutputter;
 
 public class RefersToRelationship extends BaseRelationship {
@@ -26,7 +23,7 @@ public class RefersToRelationship extends BaseRelationship {
 	}
 
 	public void addSeedTable(Table seedTable) {
-		this.seedTable = seedTable;	
+		this.seedTable = seedTable;
 	}
 
 	@Override
@@ -40,6 +37,9 @@ public class RefersToRelationship extends BaseRelationship {
 
     @Override
     public void verify() {
+        if (seedTable == null) {
+            throw new ExtractionModel.TableMissingException("attept to reference non existant table " + seedTableName);
+        }
         seedTable.getColumnWithName(seedColumnName); // throws if missing
     }
 

--- a/extractor/src/main/java/org/databaseliner/extraction/RefersToRelationship.java
+++ b/extractor/src/main/java/org/databaseliner/extraction/RefersToRelationship.java
@@ -38,6 +38,11 @@ public class RefersToRelationship extends BaseRelationship {
 		return seedTable.getColumnWithName(seedColumnName);
 	}
 
+    @Override
+    public void verify() {
+        seedTable.getColumnWithName(seedColumnName); // throws if missing
+    }
+
 	@Override
 	public String toString() {
 		return String.format("data in [%s.%s] will populate [%s.%s]", seedTableName, seedColumnName, tableName, column);
@@ -47,6 +52,7 @@ public class RefersToRelationship extends BaseRelationship {
 	public String toHtmlString() {
 		return String.format("data in [%s.%s] will populate <a href=\"#%s\">[%s.%s]</a>", seedTableName, seedColumnName, tableName.getHtmlIdSafeName(), tableName, column);
 	}
+
 
 	@Override
 	protected List<String> getExtractionSqlStrings(List<Row> dirtyRows, Table dirtyTable, SqlStringOutputter sqlStringOutputter) {

--- a/extractor/src/main/java/org/databaseliner/extraction/Relationship.java
+++ b/extractor/src/main/java/org/databaseliner/extraction/Relationship.java
@@ -17,7 +17,9 @@ public interface Relationship {
 	void setTableToFill(Table tableToFill);
 
 	void satisfyForRows(List<Row> dirtyRows, Table dirtyTable, DatabaseConnector databaseConnector);
-	
+
+    void verify();
+
 	String toHtmlString();
 
 }

--- a/extractor/src/main/java/org/databaseliner/extraction/model/ExtractionModel.java
+++ b/extractor/src/main/java/org/databaseliner/extraction/model/ExtractionModel.java
@@ -47,6 +47,11 @@ public class ExtractionModel {
 			Table seededTable = addTable(seedExtraction.getTableName());
 			seedExtraction.setTableToFill(seededTable);
 		}
+
+        // all relationships should now be correctly bound in the model
+        for (Relationship relationship : relationships) {
+            relationship.verify();                
+        }
 	}
 
 	private Table addTable(TableName tableName) {
@@ -75,11 +80,18 @@ public class ExtractionModel {
 		ResultSet columnSet = null;
 		try {
 			columnSet = databaseMetaData.getColumns(null, table.getName().getSchemaName(), table.getName().getTableName(), null);
-	
+
+            boolean tableExists = false;
+
 	        while (columnSet.next()) {
+                tableExists = true;
 	            int nullability = columnSet.getInt("NULLABLE");
 	            table.addColumn(new Column(columnSet.getString("COLUMN_NAME"), (nullability == DatabaseMetaData.columnNullable)));
 	        }
+
+            if (!tableExists) {
+                throw new RuntimeException("Unable to get column data for " + table);
+            }
 	        
 		} catch (SQLException e) {
 			
@@ -177,6 +189,7 @@ public class ExtractionModel {
 		}
 		
 		for (Relationship relationship : userRelationshipsForTable) {
+
 			TableName tableNameToFill = relationship.getTableName();
 			if (tableNameToFill.getSchemaName() == null) {
 				tableNameToFill.setSchemaName(table.getName().getSchemaName());

--- a/extractor/src/main/java/org/databaseliner/extraction/model/ExtractionModel.java
+++ b/extractor/src/main/java/org/databaseliner/extraction/model/ExtractionModel.java
@@ -90,7 +90,7 @@ public class ExtractionModel {
 	        }
 
             if (!tableExists) {
-                throw new RuntimeException("Unable to get column data for " + table);
+                throw new TableMissingException("Unable to get column data for " + table);
             }
 	        
 		} catch (SQLException e) {
@@ -277,4 +277,12 @@ public class ExtractionModel {
 		return SqlStringOutputter.instance(databaseConnector);
 	}
 
+    public static class TableMissingException extends RuntimeException {
+
+        private static final long serialVersionUID = 1L;
+
+        public TableMissingException(String message) {
+            super(message);
+        }
+    }
 }

--- a/extractor/src/main/java/org/databaseliner/extraction/model/Table.java
+++ b/extractor/src/main/java/org/databaseliner/extraction/model/Table.java
@@ -352,6 +352,5 @@ public class Table {
 		public ColumnMissingException(String message) {
 			super(message);
 		}
-
 	}
 }


### PR DESCRIPTION
When running databaseliner in dryrun mode, it can be useful to quickly see if the extraction could potentially work or not, instead of having to run the full, potentially slow, extract.
